### PR TITLE
ubutu version e  sdk dotnet version

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:22.04
 
 RUN apt update
 RUN apt --yes install sudo
@@ -11,7 +11,7 @@ RUN cd /etc/apt/preferences.d && \
 # Update packages
 RUN apt update
 # Install .NET SDK 6.0
-RUN apt --yes install dotnet-sdk-6.0
+RUN apt --yes install dotnet-sdk-8.0
 # Add .NET tools directory to PATH
 RUN echo 'export PATH="$PATH:$HOME/.dotnet/tools"' >> /root/.bashrc
 # Restarting shell for envariment variable changes


### PR DESCRIPTION
Fixando imagem do ubuntu utilizada e usando a versao do sdk 8.0 do donet, versão adequada para a ferramenta cli firely